### PR TITLE
Define targets for each environment when deploying

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pomodorino",
   "productName": "Pomodorino",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "main.js",
   "scripts": {
@@ -26,7 +26,35 @@
   "build": {
     "appId": "Pomodorino",
     "mac": {
-      "category": "Time.Management"
+      "category": "Time.Management",
+      "target": [
+        {
+          "target": "dmg"
+        },
+        {
+          "target": "tar.gz"
+        }
+      ]
+    },
+    "linux": {
+      "target": [
+        {
+          "target": "AppImage"
+        },
+        {
+          "target": "tar.gz"
+        }
+      ]
+    },
+    "win": {
+      "target": [
+        {
+          "target": "portable"
+        },
+        {
+          "target": "zip"
+        }
+      ]
     }
   },
   "postinstall": "electron-builder install-app-deps"


### PR DESCRIPTION
After learning a bit more about electron-builder, I'm trying to create targets that will work in all environments.

Mac still not tested.

Windows is working but the Portable app takes a while to open, as I think it's unpacking every time it's opened.